### PR TITLE
Enforce torrent traffic-encryption by default

### DIFF
--- a/src/root/.rtorrent.rc
+++ b/src/root/.rtorrent.rc
@@ -22,8 +22,8 @@ dht = disable
 #dht = auto
 #dht_port = 6880
 
-#encryption = allow_incoming,require,require_rc4
-encryption = allow_incoming,try_outgoing,enable_retry
+encryption = allow_incoming,require,require_rc4
+#encryption = allow_incoming,try_outgoing,enable_retry
 
 peer_exchange = no
 


### PR DESCRIPTION
Security should be default, not opt-in.
